### PR TITLE
attr<- changed to setattr

### DIFF
--- a/R/segregation.R
+++ b/R/segregation.R
@@ -150,7 +150,7 @@ prepare_data <- function(data, group, unit, weight, within = NULL) {
     # collapse on vars, and select only positive weights
     data.table::setDT(data)
     data <- data[freq > 0, list(freq = sum(freq)), by = vars]
-    attr(data, "vars") <- vars
+    setattr(data, "vars", vars)
     setkey(data, NULL)
     data
 }


### PR DESCRIPTION
Hi,
Thanks for using data.table!  I'm working on releasing v1.12.4 to CRAN and reverse dependency testing shows that `segregation` is affected.
With the new version, `example(mutual_difference)` throws this warning, and then fails with an error later because of it.

```
./segregation.Rcheck/00check.log:The error most likely occurred in:
./segregation.Rcheck/00check.log:> ### Name: mutual_difference
./segregation.Rcheck/00check.log:> ### Title: Decomposes the difference between two M indices
./segregation.Rcheck/00check.log:> ### Aliases: mutual_difference
./segregation.Rcheck/00check.log:> 
./segregation.Rcheck/00check.log:> ### ** Examples
./segregation.Rcheck/00check.log:> 
./segregation.Rcheck/00check.log:> # decompose the difference in school segregation between 2000 and 2005,
./segregation.Rcheck/00check.log:> # using the Shapley method
./segregation.Rcheck/00check.log:> mutual_difference(schools00, schools05, group = "race", unit = "school",
./segregation.Rcheck/00check.log:+     weight = "n", method = "shapley", precision = .1)
./segregation.Rcheck/00check.log:Warning in `[.data.table`(data, , `:=`(n_unit, sum(get(weight))), by = unit) :
./segregation.Rcheck/00check.log:

Invalid .internal.selfref detected and fixed by taking a (shallow) copy of the
data.table so that := can add this new column by reference. At an earlier point,
this data.table has been copied by R (or was created manually using structure()
or similar). Avoid names<- and attr<- which in R currently (and oddly) may copy
the whole data.table. Use set* syntax instead to avoid copying: ?set, ?setnames
and ?setattr. If this message doesn't help, please report your use case to the
data.table issue tracker so the root cause can be fixed or this message improved.

./segregation.Rcheck/00check.log:Error in first(p_unit) : object 'p_unit' not found
./segregation.Rcheck/00check.log:Calls: mutual_difference ... method -> shapley_compute -> m -> [ -> [.data.table -> first
./segregation.Rcheck/00check.log:Execution halted
```

I've tested that this PR will fix the problem. The long warning (and its advice not to use `attr<-`) is long-standing but it wasn't being generated before for your package. Your package was working, and without warning too, because we were using an internal R trick which we've had to remove as the trick it will be removed from R soon. Fortunately, the warning that is now generated is correct and it's a shame we didn't manage to detect the use of `attr<-` before.

Please can you merge this PR and send a new version to CRAN?  It will work with the current version of data.table (1.12.2) too so you don't need to wait for the new version to be released.

Best, Matt
