### PR TITLE
test_ipf.R: match groups before test equal

### DIFF
--- a/tests/testthat/test_ipf.R
+++ b/tests/testthat/test_ipf.R
@@ -10,17 +10,19 @@ test_that("different precisions", {
         adj <- ipf(schools00_r, schools05_r, "race", "school", weight = "n", precision = precision)
 
         # check that the new "race" marginals are similar to the target marginals
-        new <- aggregate(adj$n, list(adj$race), sum)[, "x"]
-        old <- aggregate(schools05_r$n, list(schools05_r$race), sum)[, "x"]
-        new <- new / sum(new)
-        old <- old / sum(old)
+        new <- aggregate(adj$n, list(adj$race), sum)
+        old <- aggregate(schools05_r$n, list(schools05_r$race), sum)
+        old <- old[match(new$Group.1, old$Group.1), ]
+        new <- new$x / sum(new$x)
+        old <- old$x / sum(old$x)
         expect_true(all(abs(new - old) < precision))
 
         # check that the new "school" marginals are similar to the target marginals
-        new <- aggregate(adj$n, list(adj$school), sum)[, "x"]
-        old <- aggregate(schools05_r$n, list(schools05_r$school), sum)[, "x"]
-        new <- new / sum(new)
-        old <- old / sum(old)
+        new <- aggregate(adj$n, list(adj$school), sum)
+        old <- aggregate(schools05_r$n, list(schools05_r$school), sum)
+        old <- old[match(new$Group.1, old$Group.1), ]
+        new <- new$x / sum(new$x)
+        old <- old$x / sum(old$x)
         expect_true(all(abs(new - old) < precision))
     }
 })


### PR DESCRIPTION
Adjustment to the test to cope if `aggregate()` returns the groups in a different order. The added `match()` ensures that the result for each group is compared without an assumption that the `new` and `old` result has the groups in the same order.

With the current dev version of data.table 1.13.7 (to be released as 1.13.8), news item 2 is :

> fintersect() now retains the order of the first argument as reasonably expected, rather than retaining the order of the second argument, #4716. Thanks to Michel Lang for reporting, and Ben Schwen for the PR.

which affects the `fintersect()` calls in `create_common_data()`. The first call affected being https://github.com/elbersb/segregation/blob/master/R/ipf.R#L93. Eventually the test receives `new` and `old` containing the correct group results as before, but in a slightly different order, as follows.

```
> library("segregation")
> schools00_r <- schools00[schools00$school %in% schools05$school, ]
> schools05_r <- schools05[schools05$school %in% schools00$school, ]
> 
> adj <- ipf(schools00_r, schools05_r, "race", "school", weight = "n", precision = 0.1)
>           
> new <- aggregate(adj$n, list(adj$race), sum)
> old <- aggregate(schools05_r$n, list(schools05_r$race), sum)
> 
> new
  Group.1      x
1   asian  17494
2   black 122787
3    hisp 116932
4   white 468978
5  native   5879
> old
  Group.1      x
1   asian  22508
2   black 117527
3    hisp 147052
4  native   6085    # last 2 groups switched position
5   white 441050
```

This was highlighted by revdep testing of data.table in dev, https://github.com/elbersb/segregation/issues/5.
Linking to the revdep status tracking issue, https://github.com/Rdatatable/data.table/issues/4866.
Linking to the change to `data.table::fintersect()`, https://github.com/Rdatatable/data.table/issues/4716.

If it looks ok to you, there's no rush at all but when you have a chance could you merge and publish to CRAN please. Otherwise `data.table` will break `segregation`'s tests on CRAN on the next update. Thanks!  I checked that with this PR, `segregation` passes `R CMD check` with both current release of `data.table` (1.13.6), and the dev version (so you don't need to wait for the new version to be released).